### PR TITLE
General Fixes and Item Randomizer v3 Compatibility

### DIFF
--- a/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizer.cs
+++ b/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizer.cs
@@ -471,6 +471,11 @@ namespace EnemyRandomizerMod
 
         void CheckAndDisableLogicInMenu( Scene from, Scene to )
         {
+            if (EnemyRandomizerLoader.Instance.DatabaseGenerated)           // Force start of StartRandomEnemyLocator to prevent Item Randomizer interrupt
+            {
+                EnableEnemyRandomizer();
+                EnemyRandomizerLogic.Instance.StartRandomEnemyLocator(from, to);
+            }
             if( to.name == Menu.RandomizerMenu.MainMenuSceneName )
             {
                 DisableEnemyRandomizer();

--- a/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizer.cs
+++ b/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizer.cs
@@ -22,9 +22,10 @@ namespace EnemyRandomizerMod
 
         string fullVersionName = "0.3.0";
         string modRootName = "RandoRoot";
+        bool loadedGame = false;
 
         //public const bool kmode = true;
-        
+
         GameObject modRoot;
         public GameObject ModRoot {
             get {
@@ -471,14 +472,16 @@ namespace EnemyRandomizerMod
 
         void CheckAndDisableLogicInMenu( Scene from, Scene to )
         {
-            if (EnemyRandomizerLoader.Instance.DatabaseGenerated)           // Force start of StartRandomEnemyLocator to prevent Item Randomizer interrupt
+            if (EnemyRandomizerLoader.Instance.DatabaseGenerated && !loadedGame)           // Force start of StartRandomEnemyLocator to prevent Item Randomizer interrupt
             {
                 EnableEnemyRandomizer();
+                loadedGame = true;
                 EnemyRandomizerLogic.Instance.StartRandomEnemyLocator(from, to);
             }
             if( to.name == Menu.RandomizerMenu.MainMenuSceneName )
             {
                 DisableEnemyRandomizer();
+                loadedGame = false;
             }
         }
 
@@ -510,6 +513,7 @@ namespace EnemyRandomizerMod
             {
                 GameSeed = OptionsMenuSeed;
             }
+            loadedGame = true;
 
             EnableEnemyRandomizer();
         }
@@ -524,6 +528,11 @@ namespace EnemyRandomizerMod
 
         void EnableEnemyRandomizer()
         {
+            if (!loadedGame || PlayerSettingsSeed == -1)             // Grab OptionMenuSeed on new game or if current file does not have variable in settings
+            {
+                GameSeed = OptionsMenuSeed;
+                PlayerSettingsSeed = GameSeed;
+            }
             Dev.Where();
             Tools.SetNoclip( false );
             RandomizerReady = true;

--- a/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizerDatabase.cs
+++ b/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizerDatabase.cs
@@ -1180,6 +1180,28 @@ namespace EnemyRandomizerMod
             "Grimm Boss" // as above
         };
 
+        // ghost warriors to fix essence not dropping issues
+        public static List<string> ghostWarriors = new List<string>()
+        {
+            "Ghost Warrior No Eyes",
+            "Ghost Warrior Hu",
+            "Ghost Warrior Marmu",
+            "Ghost Warrior Slug",
+            "Ghost Warrior Xero",
+            "Ghost Warrior Galien",
+            "Ghost Warrior Markoth",
+        };
+
+        // enemies with special endings that are not (currently) known to be transferable
+        public static List<string> specialEndings = new List<string>()
+        {
+            "Grimm Boss",
+            "Mage Lord",
+            "Mawlek Body",
+            "Mantis Traitor Lord"
+        };
+
+
         /*
          * 
  * 

--- a/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizerDatabase.cs
+++ b/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizerDatabase.cs
@@ -517,7 +517,15 @@ namespace EnemyRandomizerMod
          * 
          */
 
-
+        public static List<string> skipUsingAsRandomized = new List<string>()           // prevent using these enemies as replacements
+        {
+            "Hatcher Baby",                     // In old notes as causing problems
+            "Roller",                           // Causes Exception on database check
+            "Moss Charger",                     // Causes Exception on spawn
+            "Moss Knight B",                    // In old notes as causing problems
+            "Moss Knight C",                    // In old notes as causing problems
+            "Ghost Warrior Marmu"               // Causes random hardlocks
+        };
 
 
         //effects used by enemies, like crystal guardian, or just things we can use for fun
@@ -911,7 +919,8 @@ namespace EnemyRandomizerMod
             "Crawler",
             "Ordeal Zoteling",
             "Zote Crew Normal",
-            "Zote Balloon Ordeal"
+            "Zote Balloon Ordeal",
+            "Jellyfish Baby"                // Was not in any size list, causing Fog Canyon rooms not to randomize
         };
 
         public static List<string> mediumEnemyTypeNames = new List<string>()

--- a/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizerLoader.cs
+++ b/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizerLoader.cs
@@ -503,6 +503,15 @@ namespace EnemyRandomizerMod
             randomizerSceneProcessor = null;
 
             GameManager.instance.LoadFirstScene();
+            for (int i = 0; i < UnityEngine.SceneManagement.SceneManager.sceneCount; i++)               // Clear out extra loaded scenes to prevent inital load issue
+            {
+                Scene scene = UnityEngine.SceneManagement.SceneManager.GetSceneAt(i);
+
+                if (scene != UnityEngine.SceneManagement.SceneManager.GetActiveScene())
+                {
+                    UnityEngine.SceneManagement.SceneManager.UnloadSceneAsync(scene);
+                }
+            }
         }
 
         protected virtual bool IsDoneLoadingRandomizerData()

--- a/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizerLogic.cs
+++ b/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizerLogic.cs
@@ -11,6 +11,7 @@ using UnityEngine.SceneManagement;
 using UnityEngine;
 using System.Reflection;
 using HutongGames.PlayMaker.Actions;
+using HutongGames.PlayMaker;
 
 using Bounds = UnityEngine.Bounds;
 
@@ -556,6 +557,27 @@ namespace EnemyRandomizerMod
                 }
             }
 
+            // Checks if enemy has a roar, then disable the roar by skipping over the roar state
+            // Fixes the roar push out of bounds on room entry issue. Workaround until I work out how to disable the stun/push
+            PlayMakerFSM control = FSMUtility.GetFSM(newEnemy);
+            if (control != null)
+            {
+                FsmState roar = control.FsmStates.Where(state => state.Name == "Roar").FirstOrDefault();
+                
+                if (roar != null)
+                {
+                    foreach (FsmState fsmS in control.FsmStates)
+                    {
+                        foreach (FsmTransition trans in fsmS.Transitions)
+                        {
+                            if (trans.ToState == "Roar")
+                            {
+                                trans.ToState = "Roar End";
+                            }
+                        }
+                    }
+                }
+            }
 
             //put replaced enemies in a "box of doom"
             //when tied enemy is kiled, kill the replaced enemy in the box

--- a/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizerLogic.cs
+++ b/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizerLogic.cs
@@ -147,8 +147,10 @@ namespace EnemyRandomizerMod
         //entry point into the replacement logic, started on each scene transition
         public void StartRandomEnemyLocator( Scene from, Scene to )
         {
+            if (!EnemyRandomizerLoader.Instance.DatabaseGenerated)          // Ensure that the database is loaded to prevent possible issues with new game launch
+                return;
             //"disable" the randomizer when we enter the title screen, it's enabled when a new game is started or a game is loaded
-            if( to.name == Menu.RandomizerMenu.MainMenuSceneName )
+            if ( to.name == Menu.RandomizerMenu.MainMenuSceneName )
                 return;
 
             Dev.Log( "Transitioning FROM [" + from.name + "] TO [" + to.name + "]" );
@@ -156,6 +158,21 @@ namespace EnemyRandomizerMod
             //ignore randomizing on the menu/movie intro scenes
             if( to.buildIndex < 4 )
                 return;
+
+            if (!to.name.Contains("boss"))                                  // Prevent softlock on leaving certain boss rooms
+            {
+                for (int i = 0; i < UnityEngine.SceneManagement.SceneManager.sceneCount; i++)       // Clear out all non-active scenes to prevent room over room loading issue
+                {
+                    Scene scene = UnityEngine.SceneManagement.SceneManager.GetSceneAt(i);
+
+                    if (scene != to && scene != from)
+                    {
+                        UnityEngine.SceneManagement.SceneManager.UnloadSceneAsync(scene);
+                    }
+                }
+
+                UnityEngine.SceneManagement.SceneManager.SetActiveScene(to);
+            }
 
             Dev.Where();
             replacements.Clear();

--- a/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizerLogic.cs
+++ b/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizerLogic.cs
@@ -505,6 +505,8 @@ namespace EnemyRandomizerMod
             if (storedEnemy != null)
                 storedEnemy = null;
 
+            if (UnityEngine.SceneManagement.SceneManager.GetActiveScene().name == "Hive_04" && oldEnemy.gameObject.name == "Big Bee (3)")       // Prevents a Big Bee randomization in room where it is needed to break wall
+                return;
             GameObject newEnemy = InstantiateEnemy(replacementPrefab,oldEnemy);
 
             //temporary, origianl name used to configure the enemy
@@ -1634,7 +1636,7 @@ namespace EnemyRandomizerMod
                 Dev.Log( "Attempted replacement index: " + temp + " which is " + tempName );
                 
                 //this one is broken for now....
-                if( tempName.Contains( "Hatcher Baby" ) )
+                if(EnemyRandomizerDatabase.skipUsingAsRandomized.Contains(tempName))
                     continue;
 
                 Dev.Log( " with prefab name " + tempPrefab.name );

--- a/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizerLogic.cs
+++ b/EnemyRandomizerDll/EnemyRandomizer/EnemyRandomizerLogic.cs
@@ -145,7 +145,7 @@ namespace EnemyRandomizerMod
         }
 
         //entry point into the replacement logic, started on each scene transition
-        void StartRandomEnemyLocator( Scene from, Scene to )
+        public void StartRandomEnemyLocator( Scene from, Scene to )
         {
             //"disable" the randomizer when we enter the title screen, it's enabled when a new game is started or a game is loaded
             if( to.name == Menu.RandomizerMenu.MainMenuSceneName )

--- a/EnemyRandomizerDll/EnemyRandomizer/Extensions/StringExtensions.cs
+++ b/EnemyRandomizerDll/EnemyRandomizer/Extensions/StringExtensions.cs
@@ -32,8 +32,8 @@ namespace EnemyRandomizerMod
             "Hiveling Spawner",
             "Jellyfish Baby Inert",
             "Cap Hit",
-            "Moss Knight C",
-            "Moss Knight B",
+            //"Moss Knight C",
+            //"Moss Knight B",
             "Giant Buzzer",
             "Plant Turret Right",
             "Shell",
@@ -56,7 +56,7 @@ namespace EnemyRandomizerMod
             "Zoteling",
 
             //TEMP: remove these enemies until they're fixed
-            "Mage Lord Phase2",
+            //"Mage Lord Phase2",
             "Mega Moss Charger",
             "Dung Defender",
             "White Defender",

--- a/EnemyRandomizerDll/EnemyRandomizer/UI/RandomizerMenu.cs
+++ b/EnemyRandomizerDll/EnemyRandomizer/UI/RandomizerMenu.cs
@@ -448,7 +448,7 @@ namespace EnemyRandomizerMod.Menu
 
             RemoveGarbageMenuOptions();
 
-            backButton = optionsMenuScreen.defaultHighlight.FindSelectableOnUp();
+            backButton = optionsMenuScreen.defaultHighlight.FindSelectableOnUp().FindSelectableOnUp();          // Fix menu back button not closing Enemy Randomizer submenu
 
             //find a toggle-able menu element to use for our mod option prefab
             SetupMenuTogglePrefab();


### PR DESCRIPTION
Fixes to the following issues:

- Enemy Randomizer options menu not closing and causing overlapping menus
- Seed value not retained on reloading game
- Overlapped room loading
- Blacked-out room upon leaving certain boss encounters
- Grimm Chest spawn failure and some related events failing after a fight
- Bosses used as replacements causing player to clip through floor with roar (temp roar disable)
- Some rooms failing to randomize due to exceptions (by list adjustments or removal from pool)
- Enemies not randomizing on first load  after creating a new Item Randomizer v3 file
